### PR TITLE
Project Code Review and Assessment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,6 +177,13 @@ cython_debug/
 test_pdfs/*_analysis.txt
 test_pdfs/*_analysis.json
 
+# Extracted code from PDFs (JavaScript, shell scripts, etc.)
+*.pdf_js_*.js
+*.pdf_sh_*.sh
+*.pdf_bat_*.bat
+*.pdf_ps1_*.ps1
+*_extracted_code/
+
 # Keep test PDFs in git for CI
 !test_malicious*.pdf
 !test_pdfs/


### PR DESCRIPTION
Add patterns to ignore extracted code files from PDF analysis:
- JavaScript files (*.pdf_js_*.js)
- Shell scripts (*.pdf_sh_*.sh)
- Batch files (*.pdf_bat_*.bat)
- PowerShell scripts (*.pdf_ps1_*.ps1)
- Extracted code directories (*_extracted_code/)

These are generated artifacts from code extraction and should not be committed to version control.


# Pull Request

## Description

Briefly describe the changes you are proposing.

## Related Issue

Fixes #(issue number)

## Type of Change

Please check the options that are relevant:

- [ ] Bug fix (non-breaking change that fixes an issue)

- [ ] New feature (non-breaking change that adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

- [ ] Documentation update

- [ ] Performance improvement

- [ ] Code refactoring

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- Test A

- Test B

## Screenshots

If applicable, add screenshots to help explain your changes.

## Checklist

- [ ] My code follows the style guidelines of this project

- [ ] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [ ] I have made corresponding changes to the documentation

- [ ] My changes generate no new warnings

- [ ] I have added tests that prove my fix is effective or that my feature works

- [ ] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules

## Summary by Sourcery

Ignore generated PDF-extracted code artifacts in version control

Chores:
- Add .gitignore entries for JavaScript files generated from PDFs (*.pdf_js_*.js)
- Add .gitignore entries for shell scripts generated from PDFs (*.pdf_sh_*.sh)
- Add .gitignore entries for batch files generated from PDFs (*.pdf_bat_*.bat)
- Add .gitignore entries for PowerShell scripts generated from PDFs (*.pdf_ps1_*.ps1)
- Add .gitignore entry to ignore extracted code directories (*_extracted_code/)