### PR TITLE
fix(ci,deps): unblock Python 3.9 matrix and patch black CVE GHSA-3936-cmfr-pm3m

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "black==26.1.0" isort mypy ruff types-requests
+          pip install "black==26.3.1" isort mypy ruff types-requests
           pip install -r requirements.txt
       - name: Check formatting with Black
         run: black --check .
@@ -100,7 +100,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest "black==26.1.0"
+          pip install pytest "black==26.3.1"
 
       - name: Check code formatting
         run: black --check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 dev = [
     "pytest>=7.0.0",
     "pytest-mock>=3.10.0",
-    "black>=23.0.0",
+    "black>=26.3.1; python_version >= '3.10'",
     "isort>=5.10.0",
     "mypy>=1.0.0",
     "pre-commit>=3.3.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Core dependencies
+# Runtime dependencies
 requests>=2.28.0
 watchdog>=3.0.0
 pygments>=2.15.0  # For syntax highlighting
@@ -12,10 +12,7 @@ colorama>=0.4.6   # For cross-platform terminal colors (optional but recommended
 #   2. Consider using Docker to containerize the application
 #   3. The application will still work without YARA
 
-# Development dependencies
-pytest>=7.0.0  # For running tests
-pytest-mock>=3.10.0  # For mocking in tests
-black==26.1.0  # For code formatting (pinned to match pre-commit and CI)
-isort>=5.10.0  # For import sorting
-mypy>=1.0.0   # For type checking
-pre-commit>=3.3.0  # For pre-commit hooks
+# Development dependencies are declared in pyproject.toml under
+# [project.optional-dependencies].dev — install with:
+#     pip install -e .[dev]
+# Tools like black require Python >= 3.10, while runtime supports 3.9+.


### PR DESCRIPTION
## Root Cause

Both push CI on `main` and the Dependabot security update for black were failing for the **same** reason — there was no PR-level conflict despite Dependabot's filing (`conflicting-dependencies: []`).

- `requirements.txt` pinned `black==26.1.0`
- The CI matrix tests Python 3.9, 3.10, 3.11, 3.12
- black >= 26.x requires Python >= 3.10
- `pip install -r requirements.txt` therefore failed on the 3.9 row, and Dependabot's `->26.3.1` patch hit the same wall (`security_update_not_possible`)

## Fix

- **`requirements.txt`** — drop dev deps (already declared in `pyproject.toml [project.optional-dependencies].dev`). Runtime install on 3.9 no longer pulls a Python-3.10-only black.
- **`.github/workflows/ci.yml`** — bump pinned `black==26.1.0` → `26.3.1` in lint and quick-verify jobs (CVE patched).
- **`pyproject.toml`** — gate the dev-extra black on `python_version >= '3.10'`, matching upstream black's `requires-python`. 3.9 runtime support is preserved.

## Verification

- All four matrix rows (3.9 / 3.10 / 3.11 / 3.12) should now install cleanly.
- Dependabot security alert GHSA-3936-cmfr-pm3m should auto-close once this lands on `main`.
- Lint + quick-verify continue to run black 26.3.1 on Python 3.12.

---
*Auto-generated by /health-guardian*

## Summary by Sourcery

Unblock Python 3.9 CI and update Black to a non-vulnerable version while delegating dev dependencies to pyproject configuration.

Bug Fixes:
- Resolve CI failures on the Python 3.9 matrix row by removing Python-3.10-only dev tools from runtime requirements.

Enhancements:
- Clarify requirements.txt as runtime-only and point developers to pyproject-based dev extras.
- Gate the Black dev dependency to Python 3.10+ to align with its supported versions and maintain 3.9 runtime compatibility.
- Bump Black to version 26.3.1 in pyproject and CI workflows to pick up the latest security fix.

CI:
- Update CI workflows to install Black 26.3.1 in lint and quick-verify jobs instead of 26.1.0.