### PR TITLE
fix(ci): pin bandit<1.9.0 to resolve Security Scan failure

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "bandit<1.9.0" safety
+          pip install "bandit<1.9.0" "safety<3.0.0"
           # Install core dependencies to enable proper scanning
           pip install -r requirements.txt
       - name: Run Bandit security scan

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install bandit safety
+          pip install "bandit<1.9.0" safety
           # Install core dependencies to enable proper scanning
           pip install -r requirements.txt
       - name: Run Bandit security scan


### PR DESCRIPTION
bandit 1.9.x introduced a breaking --policy-file validation that emits "Policy file YAML is not valid" and exits with code 2 even when no policy file is passed. Pin to <1.9.0 to restore the pre-1.9 behaviour while a proper migration to the new API is evaluated.


# Pull Request

## Description

Briefly describe the changes you are proposing.

## Related Issue

Fixes #(issue number)

## Type of Change

Please check the options that are relevant:

- [ ] Bug fix (non-breaking change that fixes an issue)

- [ ] New feature (non-breaking change that adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

- [ ] Documentation update

- [ ] Performance improvement

- [ ] Code refactoring

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- Test A

- Test B

## Screenshots

If applicable, add screenshots to help explain your changes.

## Checklist

- [ ] My code follows the style guidelines of this project

- [ ] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [ ] I have made corresponding changes to the documentation

- [ ] My changes generate no new warnings

- [ ] I have added tests that prove my fix is effective or that my feature works

- [ ] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules

## Summary by Sourcery

CI:
- Update the security workflow to install bandit<1.9.0 instead of the latest bandit to stabilize the Bandit security scan job.