### PR TITLE
fix(ci): replace safety v2 check with pip-audit

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install bandit safety
+          pip install bandit pip-audit
           # Install core dependencies to enable proper scanning
           pip install -r requirements.txt
       - name: Run Bandit security scan
@@ -43,6 +43,5 @@ jobs:
           echo "No obvious hardcoded secrets found."
       - name: Check dependencies for vulnerabilities
         run: |
-          # Check requirements.txt for security vulnerabilities
-          # Ignore development dependencies, commented items, and optional dependencies
-          cat requirements.txt | grep -v "^#" | grep -v "optional" | safety check --stdin
+          # pip-audit replaces safety v2 — works without auth, actively maintained by PyPA
+          pip-audit -r requirements.txt


### PR DESCRIPTION
## Problem

The Security Scan has been failing for two weeks (W20 + W21 orchestrator CRITICAL alerts). Root cause: `pip install bandit safety` installs **safety v3.7.0**, which dropped the `safety check --stdin` command and now requires API authentication. The old command exits with code 2, failing the step.

## Fix

Replace `safety` with `pip-audit` — the PyPA-maintained successor:
- No API key or authentication needed
- Same vulnerability coverage (PyPI advisory database)
- Actively maintained
- `pip-audit -r requirements.txt` replaces the old `safety check --stdin` pipe

## Changes

- `security.yml`: `pip install bandit safety` → `pip install bandit pip-audit`
- `security.yml`: `cat requirements.txt | ... | safety check --stdin` → `pip-audit -r requirements.txt`

## Test plan

- [ ] CI green on this PR
- [ ] Confirm orchestrator no longer flags malwarespotter as CRITICAL next Monday run
- [ ] Close orchestrator issues #4 and #6 in docdyhr/.github after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Update the security workflow to install pip-audit instead of safety for dependency vulnerability scanning.