### PR TITLE
chore(ci): migrate security scan to reusable caller

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,47 +1,14 @@
 name: Security Scan
-
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
   schedule:
-    - cron: "0 0 * * 0" # Run weekly
-
+    - cron: "0 0 * * 0" # Weekly Sunday 00:00 UTC
 jobs:
-  security-scan:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install bandit pip-audit
-          # Install core dependencies to enable proper scanning
-          pip install -r requirements.txt
-      - name: Run Bandit security scan
-        run: |
-          # Exclude test files and temporary files from security scan
-          # Also ignore specific security warnings that have been reviewed and deemed safe:
-          # B404: Import of subprocess module (used for sandboxed PDF viewing)
-          # B603: subprocess without shell=True (intentional, for security)
-          # B605: start_process_with_shell=True (skipped for intentional calls)
-          # B606: start_process_with_no_shell (intentional for Windows)
-          # B607: start_process_with_partial_path (skipped for intentional)
-          # B110: try_except_pass (intentional in specified cases)
-          # B108: hardcoded_tmp_directory (intentional --tmpfs /tmp mount in bwrap sandbox)
-          bandit -r . --skip B404,B603,B605,B606,B607,B110,B108 -x "./test_*.py,**/.venv/**,**/tests/**,**/sample*.js,**/temp/**"
-      - name: Check for hardcoded secrets
-        run: |
-          # Look for potential API keys and secrets in code
-          echo "Checking for potential hardcoded secrets..."
-          ! grep -r --include="*.py" --include="*.json" -E "(api_key|apikey|secret|password|token|credential).*['\"][a-zA-Z0-9]{16,}['\"]" .
-          echo "No obvious hardcoded secrets found."
-      - name: Check dependencies for vulnerabilities
-        run: |
-          # pip-audit replaces safety v2 — works without auth, actively maintained by PyPA
-          pip-audit -r requirements.txt
+  security:
+    uses: docdyhr/.github/.github/workflows/security-scan.yml@v1
+    with:
+      bandit_skip: "B404,B603,B605,B606,B607,B110,B108"
+      bandit_exclude: "./test_*.py,**/.venv/**,**/tests/**,**/sample*.js,**/temp/**"


### PR DESCRIPTION
## Summary

Replaces the inline `security.yml` with a 10-line caller of the centralised reusable workflow at `docdyhr/.github/.github/workflows/security-scan.yml@v1`.

Same behaviour — Bandit + pip-audit — maintained from one place going forward. No more per-repo `safety` vs `pip-audit` drift.

## Changes

- Drops ~50 lines of inline YAML
- `bandit_skip` and `bandit_exclude` preserved as inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Migrate the repository security scan workflow to use a centralized reusable workflow while preserving existing scan behavior and configuration.

CI:
- Replace the inline security scan GitHub Actions job with a call to the shared reusable security-scan workflow.
- Retain existing Bandit configuration via workflow inputs for skip codes and excluded paths.